### PR TITLE
Introduce urfave/cli to ptt

### DIFF
--- a/cmd/ptt/main.go
+++ b/cmd/ptt/main.go
@@ -1,143 +1,111 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
-	"runtime/debug"
+
 	"strings"
 	"time"
 
 	"github.com/Bejdenn/ptt/internal/timetable"
+	"github.com/urfave/cli/v2"
 )
 
-var now = time.Now()
+func main() {
+	cli.AppHelpTemplate = fmt.Sprintf(`%s
+END and DURATION are mutually exclusive. If both are defined, the time table will use the value that results in the earlier end time.
+The format of the durations and time values are the same that the Go programming language uses for its time parsing.
+`, cli.AppHelpTemplate)
 
-type excludesMultiFlag []timetable.TimeRange
+	(&cli.App{
+		Name:  "ptt",
+		Usage: "Pomodoro time table for the terminal. Interpolates your working times for a better daily overview.",
+		Flags: []cli.Flag{
+			&cli.TimestampFlag{
+				Name:        "start",
+				Layout:      timetable.TimeOnlyNoSeconds,
+				Aliases:     []string{"s"},
+				Usage:       "Set `START` as the start time of the time table.",
+				DefaultText: "current time",
+				Value:       cli.NewTimestamp(time.Now()),
+			},
+			&cli.TimestampFlag{
+				Name:    "end",
+				Layout:  timetable.TimeOnlyNoSeconds,
+				Aliases: []string{"e"},
+				Usage:   "Set `END` as the end time of the time table. Ignored if not defined.",
+				Value:   cli.NewTimestamp(time.Time{}),
+				Action: func(c *cli.Context, end *time.Time) error {
+					if !end.IsZero() && end.Before(*c.Timestamp("start")) {
+						*end = end.AddDate(0, 0, 1)
+					}
+					return nil
+				},
+			},
+			&cli.DurationFlag{
+				Name:    "session-length",
+				Value:   90 * time.Minute,
+				Aliases: []string{"l"},
+				Usage:   "Set `LENGTH` as the length of a single pomodoro session.",
+			},
+			&cli.DurationFlag{
+				Name:    "duration",
+				Value:   time.Duration(0),
+				Aliases: []string{"d"},
+				Usage:   "Set `DURATION` as the working duration that should be covered by pomodoro sessions.",
+			},
+			&cli.DurationFlag{
+				Name:    "pause",
+				Value:   15 * time.Minute,
+				Aliases: []string{"p"},
+				Usage:   "Set `PAUSE` as the pause duration between pomodoro sessions.",
+			},
+			&cli.StringSliceFlag{
+				Name:    "exclude",
+				Aliases: []string{"x"},
+				Usage:   "Exclude `EXCLUDE` to prevent from being overlapped by a pomodoro session. Can be repeated.",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			excludes, err := parseTimeRanges(*c.Timestamp("start"), c.StringSlice("exclude"))
+			if err != nil {
+				return fmt.Errorf("cannot parse excludes: %v\n", err)
+			}
 
-func (e *excludesMultiFlag) String() string {
-	return fmt.Sprint(*e)
+			sessions, err := timetable.Generate(*c.Timestamp("start"), *c.Timestamp("end"), c.Duration("pause"), c.Duration("duration"), c.Duration("session-length"), excludes)
+			if err != nil {
+				return fmt.Errorf("cannot generate timetable: %v\n", err)
+			}
+
+			fmt.Print(sessions)
+			return nil
+		},
+	}).Run(os.Args)
 }
 
-func (e *excludesMultiFlag) Set(s string) error {
-	excludes := strings.Split(s, " ")
-	for _, exclude := range excludes {
+func parseTimeRanges(ref time.Time, args []string) ([]timetable.TimeRange, error) {
+	excludes := make([]timetable.TimeRange, 0, len(args))
+	for _, exclude := range args {
 		parts := strings.Split(exclude, "-")
 		if len(parts) != 2 {
-			return fmt.Errorf("could not parse exclude: %s", exclude)
+			return nil, fmt.Errorf("exclude did not contain hyphen delimiter: %s", exclude)
 		}
 
 		start, err := time.Parse(timetable.TimeOnlyNoSeconds, parts[0])
 		if err != nil {
-			return fmt.Errorf("could not parse start time: %v", err)
+			return nil, fmt.Errorf("could not parse start time: %v", err)
 		}
 
 		end, err := time.Parse(timetable.TimeOnlyNoSeconds, parts[1])
 		if err != nil {
-			return fmt.Errorf("could not parse end time: %v", err)
+			return nil, fmt.Errorf("could not parse end time: %v", err)
 		}
 
-		*e = append(*e, timetable.TimeRange{Start: normalize(start), End: normalize(end)})
+		excludes = append(excludes, timetable.TimeRange{Start: normalize(ref, start), End: normalize(ref, end)})
 	}
-	return nil
+	return excludes, nil
 }
 
-type timeFlag time.Time
-
-func (t *timeFlag) String() string {
-	return fmt.Sprint(*t)
-}
-
-func (t *timeFlag) Set(s string) error {
-	parsed, err := time.Parse(timetable.TimeOnlyNoSeconds, s)
-	if err != nil {
-		return fmt.Errorf("could not parse time: %v", err)
-	}
-	*t = timeFlag(normalize(parsed))
-	return nil
-}
-
-const (
-	defaultDuration      = time.Duration(0)
-	defaultSessionLength = 90 * time.Minute
-	defaultPause         = 15 * time.Minute
-)
-
-const usage = `Usage:
-    ptt [-s START] [-e END] [-l LENGTH] [-d DURATION] [-p PAUSE] (-x EXCLUDE)...
-
-Options:
-    -s, --start START            Set START as the start time of the time table. Default is current time.
-    -e, --end END                Set END as the end time of the time table. Ignored if not defined.
-    -l, --session-length LENGTH  Set LENGTH as the length of a single pomodoro session. Default is 90 minutes.
-    -d, --duration DURATION      Set DURATION as the working duration that should be covered by pomodoro sessions.
-    -p, --pause PAUSE            Set PAUSE as the pause duration between pomodoro sessions.
-    -x, --exclude EXCLUDE        Exclude EXCLUDE to prevent from being overlapped by a pomodoro session. Can be repeated.
-	
-END and DURATION are mutually exclusive. If both are defined, the time table will used that ends earlier.
-The format of the durations and time values are the same that the Go programming language uses for its time parsing.`
-
-func init() {
-	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, usage)
-	}
-}
-
-func main() {
-	var (
-		durationFlag      time.Duration
-		sessionLengthFlag time.Duration
-		pauseFlag         time.Duration
-		startFlag         timeFlag
-		endFlag           timeFlag
-		excludesFlag      excludesMultiFlag
-		versionFlag       bool
-	)
-
-	flag.DurationVar(&durationFlag, "duration", time.Duration(0), "set the working duration")
-	flag.DurationVar(&durationFlag, "d", defaultDuration, "set the working duration (shorthand)")
-	flag.DurationVar(&sessionLengthFlag, "session-length", defaultSessionLength, "set the session length")
-	flag.DurationVar(&sessionLengthFlag, "l", defaultSessionLength, "set the session length (shorthand)")
-	flag.DurationVar(&pauseFlag, "pause", defaultPause, "set the pause duration")
-	flag.DurationVar(&pauseFlag, "p", defaultPause, "set the pause duration (shorthand)")
-	flag.Var(&startFlag, "start", "set the start time")
-	flag.Var(&startFlag, "s", "set the start time (shorthand)")
-	flag.Var(&endFlag, "end", "set the end time")
-	flag.Var(&endFlag, "e", "set the end time (shorthand)")
-	flag.Var(&excludesFlag, "exclude", "exclude one or several time ranges")
-	flag.Var(&excludesFlag, "x", "exclude one or several time ranges (shorthand)")
-	flag.BoolVar(&versionFlag, "version", false, "Print the version and exit.")
-	flag.Parse()
-
-	if versionFlag {
-		if buildInfo, ok := debug.ReadBuildInfo(); ok {
-			fmt.Println(buildInfo.Main.Version)
-			return
-		}
-		fmt.Println("(unknown)")
-		return
-	}
-
-	start, end := (time.Time)(startFlag), (time.Time)(endFlag)
-
-	if start.IsZero() {
-		start = now
-	}
-
-	// if end is before start, interpret it as being the same time on the next day
-	if !end.IsZero() && end.Before(start) {
-		end = end.AddDate(0, 0, 1)
-	}
-
-	sessions, err := timetable.Generate(start, end, pauseFlag, durationFlag, sessionLengthFlag, excludesFlag)
-	if err != nil {
-		fmt.Printf("cannot generate timetable: %v\n", err)
-		return
-	}
-
-	fmt.Print(sessions)
-}
-
-func normalize(t time.Time) time.Time {
-	return time.Date(now.Year(), now.Month(), now.Day(), t.Hour(), t.Minute(), 0, 0, now.Location())
+func normalize(ref, t time.Time) time.Time {
+	return time.Date(ref.Year(), ref.Month(), ref.Day(), t.Hour(), t.Minute(), 0, 0, ref.Location())
 }

--- a/cmd/ptt/main.go
+++ b/cmd/ptt/main.go
@@ -17,6 +17,13 @@ END and DURATION are mutually exclusive. If both are defined, the time table wil
 The format of the durations and time values are the same that the Go programming language uses for its time parsing.
 `, cli.AppHelpTemplate)
 
+	cli.HelpFlag = &cli.BoolFlag{
+		Name:               "help",
+		Aliases:            []string{"h"},
+		Usage:              "Show help",
+		DisableDefaultText: true,
+	}
+
 	(&cli.App{
 		Name:  "ptt",
 		Usage: "Pomodoro time table for the terminal. Interpolates your working times for a better daily overview.",
@@ -80,6 +87,7 @@ The format of the durations and time values are the same that the Go programming
 			fmt.Print(sessions)
 			return nil
 		},
+		HideHelpCommand: true,
 	}).Run(os.Args)
 }
 

--- a/cmd/ptt/main.go
+++ b/cmd/ptt/main.go
@@ -37,11 +37,12 @@ The format of the durations and time values are the same that the Go programming
 				Value:       cli.NewTimestamp(time.Now()),
 			},
 			&cli.TimestampFlag{
-				Name:    "end",
-				Layout:  timetable.TimeOnlyNoSeconds,
-				Aliases: []string{"e"},
-				Usage:   "Set `END` as the end time of the time table. Ignored if not defined.",
-				Value:   cli.NewTimestamp(time.Time{}),
+				Name:        "end",
+				Layout:      timetable.TimeOnlyNoSeconds,
+				Aliases:     []string{"e"},
+				Usage:       "Set `END` as the end time of the time table. Ignored if not defined.",
+				DefaultText: "none",
+				Value:       cli.NewTimestamp(time.Time{}),
 				Action: func(c *cli.Context, end *time.Time) error {
 					if !end.IsZero() && end.Before(*c.Timestamp("start")) {
 						*end = end.AddDate(0, 0, 1)
@@ -56,10 +57,11 @@ The format of the durations and time values are the same that the Go programming
 				Usage:   "Set `LENGTH` as the length of a single pomodoro session.",
 			},
 			&cli.DurationFlag{
-				Name:    "duration",
-				Value:   time.Duration(0),
-				Aliases: []string{"d"},
-				Usage:   "Set `DURATION` as the working duration that should be covered by pomodoro sessions.",
+				Name:        "duration",
+				Value:       time.Duration(0),
+				Aliases:     []string{"d"},
+				DefaultText: "none",
+				Usage:       "Set `DURATION` as the working duration that should be covered by pomodoro sessions.",
 			},
 			&cli.DurationFlag{
 				Name:    "pause",

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/Bejdenn/ptt
 
 go 1.20
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/urfave/cli/v2 v2.27.2 // indirect
+	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/Bejdenn/ptt
 
 go 1.20
 
+require github.com/urfave/cli/v2 v2.27.3
+
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/urfave/cli/v2 v2.27.2 // indirect
-	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=
+github.com/urfave/cli/v2 v2.27.2/go.mod h1:g0+79LmHHATl7DAcHO99smiR/T7uGLw84w8Y42x+4eM=
+github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe9UDgpxAWQrhbbBXOYJFQDq/dtJw=
+github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913/go.mod h1:4aEEwZQutDLsQv2Deui4iYQ6DWTxR14g6m8Wv88+Xqk=

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lV
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=
-github.com/urfave/cli/v2 v2.27.2/go.mod h1:g0+79LmHHATl7DAcHO99smiR/T7uGLw84w8Y42x+4eM=
-github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe9UDgpxAWQrhbbBXOYJFQDq/dtJw=
-github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913/go.mod h1:4aEEwZQutDLsQv2Deui4iYQ6DWTxR14g6m8Wv88+Xqk=
+github.com/urfave/cli/v2 v2.27.3 h1:/POWahRmdh7uztQ3CYnaDddk0Rm90PyOgIxgW2rr41M=
+github.com/urfave/cli/v2 v2.27.3/go.mod h1:m4QzxcD2qpra4z7WhzEGn74WZLViBnMpb1ToCAKdGRQ=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=


### PR DESCRIPTION
This PR converts `ptt` to use [urfave/cli](github.com/urfave/cli) and therefore removes direct usages of the standard libary's flag handling. Hopefully, this makes future development a bit easier, concerning adding flags, reading from configuration files, etc.