### PR TITLE
Threshold flag to control how short a session can be

### DIFF
--- a/cmd/ptt/main.go
+++ b/cmd/ptt/main.go
@@ -17,9 +17,10 @@ import (
 
 type Config[T any] struct {
 	Defaults struct {
-		Duration      T `toml:"duration" env-default:"-1ns"`
-		SessionLength T `toml:"session-length" env-default:"90m"`
-		Pause         T `toml:"pause" env-default:"15m"`
+		Duration         T `toml:"duration" env-default:"-1ns"`
+		MinSessionLength T `toml:"min-session-length" env-default:"15m"`
+		MaxSessionLength T `toml:"max-session-length" env-default:"90m"`
+		Pause            T `toml:"pause" env-default:"15m"`
 	} `toml:"defaults"`
 }
 
@@ -66,14 +67,15 @@ func (t *timeFlag) Set(s string) error {
 }
 
 const usage = `Usage:
-    ptt [-s START] [-e END] [-l LENGTH] [-d DURATION] [-p PAUSE] (-x EXCLUDE)...
+    ptt [-s START] [-e END] [-l LENGTH] [-L LENGTH] [-d DURATION] [-p PAUSE] (-x EXCLUDE)...
 Options:
-    -s, --start START            Set START as the start time of the time table. Default is current time.
-    -e, --end END                Set END as the end time of the time table. Ignored if not defined.
-    -l, --session-length LENGTH  Set LENGTH as the length of a single pomodoro session. Default is 90 minutes.
-    -d, --duration DURATION      Set DURATION as the working duration that should be covered by pomodoro sessions.
-    -p, --pause PAUSE            Set PAUSE as the pause duration between pomodoro sessions.
-    -x, --exclude EXCLUDE        Exclude EXCLUDE to prevent from being overlapped by a pomodoro session. Can be repeated.
+    -s, --start START                Set START as the start time of the time table. Default is current time.
+    -e, --end END                    Set END as the end time of the time table. Ignored if not defined.
+    -l, --min-session-length LENGTH  Set LENGTH as the minimum length of a single pomodoro session. Default is 15 minutes.
+    -L, --max-session-length LENGTH  Set LENGTH as the maximum length of a single pomodoro session. Default is 90 minutes.
+    -d, --duration DURATION          Set DURATION as the working duration that should be covered by pomodoro sessions.
+    -p, --pause PAUSE                Set PAUSE as the pause duration between pomodoro sessions.
+    -x, --exclude EXCLUDE            Exclude EXCLUDE to prevent from being overlapped by a pomodoro session. Can be repeated.
 	
 END and DURATION are mutually exclusive. If both are defined, the time table will used that ends earlier.
 Defining no END or DURATION will result in an error.
@@ -114,7 +116,13 @@ func ReadConfig() Config[time.Duration] {
 		os.Exit(1)
 	}
 
-	sessionLength, err := time.ParseDuration(cfg.Defaults.SessionLength)
+	minSessionLength, err := time.ParseDuration(cfg.Defaults.MinSessionLength)
+	if err != nil {
+		fmt.Fprint(os.Stderr, durationParseErr(err))
+		os.Exit(1)
+	}
+
+	maxSessionLength, err := time.ParseDuration(cfg.Defaults.MaxSessionLength)
 	if err != nil {
 		fmt.Fprint(os.Stderr, durationParseErr(err))
 		os.Exit(1)
@@ -127,11 +135,12 @@ func ReadConfig() Config[time.Duration] {
 	}
 
 	return Config[time.Duration]{Defaults: struct {
-		Duration      time.Duration "toml:\"duration\" env-default:\"-1ns\""
-		SessionLength time.Duration "toml:\"session-length\" env-default:\"90m\""
-		Pause         time.Duration "toml:\"pause\" env-default:\"15m\""
+		Duration         time.Duration "toml:\"duration\" env-default:\"-1ns\""
+		MinSessionLength time.Duration "toml:\"min-session-length\" env-default:\"15m\""
+		MaxSessionLength time.Duration "toml:\"max-session-length\" env-default:\"90m\""
+		Pause            time.Duration "toml:\"pause\" env-default:\"15m\""
 	}{
-		duration, sessionLength, pause,
+		duration, minSessionLength, maxSessionLength, pause,
 	}}
 }
 
@@ -139,13 +148,14 @@ func main() {
 	cfg := ReadConfig()
 
 	var (
-		startFlag         = NewTimeFlag(now)
-		endFlag           = NewTimeFlag(time.Time{})
-		sessionLengthFlag time.Duration
-		durationFlag      time.Duration
-		pauseFlag         time.Duration
-		excludesFlag      excludesMultiFlag
-		versionFlag       bool
+		startFlag            = NewTimeFlag(now)
+		endFlag              = NewTimeFlag(time.Time{})
+		minSessionLengthFlag time.Duration
+		maxSessionLengthFlag time.Duration
+		durationFlag         time.Duration
+		pauseFlag            time.Duration
+		excludesFlag         excludesMultiFlag
+		versionFlag          bool
 	)
 
 	flag.Var(&startFlag, "start", "set the start time")
@@ -154,8 +164,11 @@ func main() {
 	flag.Var(&endFlag, "end", "set the end time")
 	flag.Var(&endFlag, "e", "set the end time (shorthand)")
 
-	flag.DurationVar(&sessionLengthFlag, "session-length", cfg.Defaults.SessionLength, "set the session length")
-	flag.DurationVar(&sessionLengthFlag, "l", cfg.Defaults.SessionLength, "set the session length (shorthand)")
+	flag.DurationVar(&minSessionLengthFlag, "min-session-length", cfg.Defaults.MinSessionLength, "set the session length")
+	flag.DurationVar(&minSessionLengthFlag, "l", cfg.Defaults.MinSessionLength, "set the session length (shorthand)")
+
+	flag.DurationVar(&maxSessionLengthFlag, "max-session-length", cfg.Defaults.MaxSessionLength, "set the session length")
+	flag.DurationVar(&maxSessionLengthFlag, "L", cfg.Defaults.MaxSessionLength, "set the session length (shorthand)")
 
 	flag.DurationVar(&durationFlag, "duration", cfg.Defaults.Duration, "set the working duration")
 	flag.DurationVar(&durationFlag, "d", cfg.Defaults.Duration, "set the working duration (shorthand)")
@@ -165,6 +178,7 @@ func main() {
 
 	flag.Var(&excludesFlag, "exclude", "exclude one or several time ranges")
 	flag.Var(&excludesFlag, "x", "exclude one or several time ranges (shorthand)")
+
 	flag.BoolVar(&versionFlag, "version", false, "Print the version and exit.")
 
 	flag.Parse()
@@ -185,7 +199,13 @@ func main() {
 		end = end.AddDate(0, 0, 1)
 	}
 
-	sessions, err := timetable.Generate(start, end, pauseFlag, durationFlag, sessionLengthFlag, excludesFlag)
+	sessionLength, err := timetable.NewSessionLength(minSessionLengthFlag, maxSessionLengthFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot generate timetable: %v\n", err)
+		os.Exit(1)
+	}
+
+	sessions, err := timetable.Generate(start, end, pauseFlag, durationFlag, sessionLength, excludesFlag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot generate timetable: %v\n", err)
 		os.Exit(1)

--- a/internal/timetable/timetable_test.go
+++ b/internal/timetable/timetable_test.go
@@ -14,7 +14,7 @@ func TestGenerate(t *testing.T) {
 		end           time.Time
 		pause         time.Duration
 		duration      time.Duration
-		sessionLength time.Duration
+		sessionLength SessionLength
 		excludes      []timerange.TimeRange
 	}
 	tests := []struct {
@@ -30,7 +30,7 @@ func TestGenerate(t *testing.T) {
 				end:           time.Date(2020, 1, 1, 19, 30, 0, 0, time.UTC),
 				pause:         10 * time.Minute,
 				duration:      6 * time.Hour,
-				sessionLength: 90 * time.Minute,
+				sessionLength: SessionLength{10 * time.Minute, 90 * time.Minute},
 				excludes: []timerange.TimeRange{
 					{
 						Start: time.Date(2020, 1, 1, 8, 30, 0, 0, time.UTC),
@@ -90,7 +90,7 @@ func TestGenerate(t *testing.T) {
 				end:           time.Date(2020, 1, 1, 14, 30, 0, 0, time.UTC),
 				pause:         15 * time.Minute,
 				duration:      time.Duration(-1),
-				sessionLength: 90 * time.Minute,
+				sessionLength: SessionLength{10 * time.Minute, 90 * time.Minute},
 			},
 			want: []Session{
 				{
@@ -134,7 +134,7 @@ func TestGenerate(t *testing.T) {
 				end:           time.Date(2020, 1, 1, 14, 30, 0, 0, time.UTC),
 				pause:         15 * time.Minute,
 				duration:      time.Duration(-1),
-				sessionLength: 90 * time.Minute,
+				sessionLength: SessionLength{10 * time.Minute, 90 * time.Minute},
 				excludes: []timerange.TimeRange{
 					{
 						Start: time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC),
@@ -177,7 +177,7 @@ func TestGenerate(t *testing.T) {
 				start:         time.Date(2020, 1, 1, 9, 0, 0, 0, time.UTC),
 				pause:         15 * time.Minute,
 				duration:      time.Duration(-1),
-				sessionLength: 90 * time.Minute,
+				sessionLength: SessionLength{10 * time.Minute, 90 * time.Minute},
 			},
 			wantErr: true,
 		},
@@ -187,7 +187,7 @@ func TestGenerate(t *testing.T) {
 				start:         time.Date(2020, 1, 1, 14, 2, 0, 0, time.UTC),
 				pause:         10 * time.Minute,
 				duration:      6 * time.Hour,
-				sessionLength: 90 * time.Minute,
+				sessionLength: SessionLength{10 * time.Minute, 90 * time.Minute},
 				excludes: []timerange.TimeRange{
 					{
 						Start: time.Date(2020, 1, 1, 15, 0, 0, 0, time.UTC),
@@ -233,6 +233,48 @@ func TestGenerate(t *testing.T) {
 						Start: time.Date(2020, 1, 1, 21, 0, 0, 0, time.UTC),
 						End:   time.Date(2020, 1, 1, 21, 32, 0, 0, time.UTC),
 					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "discard sessions because of minSessionLength",
+			args: args{
+				start:         time.Date(2020, 1, 1, 14, 2, 0, 0, time.UTC),
+				pause:         10 * time.Minute,
+				duration:      6 * time.Hour,
+				sessionLength: SessionLength{60 * time.Minute, 90 * time.Minute},
+				excludes: []timerange.TimeRange{
+					{
+						Start: time.Date(2020, 1, 1, 15, 0, 0, 0, time.UTC),
+						End:   time.Date(2020, 1, 1, 16, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			want: []Session{
+				{
+					ID: 1,
+					TimeRange: timerange.TimeRange{
+						Start: time.Date(2020, 1, 1, 16, 0, 0, 0, time.UTC),
+						End:   time.Date(2020, 1, 1, 17, 30, 0, 0, time.UTC),
+					},
+					Pause: 10 * time.Minute,
+				},
+				{
+					ID: 2,
+					TimeRange: timerange.TimeRange{
+						Start: time.Date(2020, 1, 1, 17, 40, 0, 0, time.UTC),
+						End:   time.Date(2020, 1, 1, 19, 10, 0, 0, time.UTC),
+					},
+					Pause: 10 * time.Minute,
+				},
+				{
+					ID: 3,
+					TimeRange: timerange.TimeRange{
+						Start: time.Date(2020, 1, 1, 19, 20, 0, 0, time.UTC),
+						End:   time.Date(2020, 1, 1, 20, 50, 0, 0, time.UTC),
+					},
+					Pause: 10 * time.Minute,
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
Closes #16.
Adds command line flag to control how long a session has to be at least. This prevents short sessions that add nothing of value to the generated table.